### PR TITLE
arm64: DT: Kugo: inherit bluesleep properties from loire-common

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8956-loire-kugo-common.dtsi
@@ -118,13 +118,7 @@
 	};
 
 	bluesleep {
-		compatible = "qcom,bluesleep";
-		bt_host_wake = <&msm_gpio 17 0x00>; /* BT_HOST_WAKE */
 		bt_ext_wake = <&msm_gpio 27 0x00>; /* BT_DEV_WAKE */
-		interrupt-parent = <&msm_gpio>;
-		interrupts = <17 0>;
-		interrupt-names = "host_wake";
-		pinctrl-names = "default", "sleep";
 		pinctrl-0 = <&msm_gpio_17_act &msm_gpio_27_def>;
 		pinctrl-1 = <&msm_gpio_17_sus &msm_gpio_27_def>;
 	};


### PR DESCRIPTION
most of the properties are identical so just inherit and only declare the differences